### PR TITLE
Feature/deprovision

### DIFF
--- a/doc/database/20180720.1.schema.sql
+++ b/doc/database/20180720.1.schema.sql
@@ -1,0 +1,25 @@
+ALTER TABLE blocks DROP CONSTRAINT "$2", ADD CONSTRAINT blocks_incident_fk
+FOREIGN KEY(incident) references incidents(id) ON DELETE CASCADE;
+
+ALTER TABLE external_incidentids DROP CONSTRAINT "$1", ADD CONSTRAINT
+ei_incidentid_fkey FOREIGN KEY(incidentid) references incidents(id) ON DELETE
+CASCADE;
+
+ALTER TABLE incident_addresses DROP CONSTRAINT "$1", ADD CONSTRAINT
+ia_incident_fk FOREIGN KEY(incident) references incidents(id) ON DELETE
+CASCADE;
+
+ALTER TABLE incident_attachments DROP CONSTRAINT
+"incident_attachments_incident_fkey", ADD CONSTRAINT ia_incident_fk FOREIGN
+KEY(incident) references incidents(id) ON DELETE CASCADE;
+
+ALTER TABLE incident_comments DROP CONSTRAINT "$1", ADD CONSTRAINT
+ic_incident_fk FOREIGN KEY(incident) references incidents(id) ON DELETE
+CASCADE;
+
+ALTER TABLE incident_mail DROP CONSTRAINT "incident_mail_incidentid_fkey", ADD
+CONSTRAINT incident_mail_incidentid_fkey FOREIGN KEY(incidentid) references
+incidents(id) ON DELETE CASCADE;
+
+ALTER TABLE incident_users DROP CONSTRAINT "$1", ADD CONSTRAINT iu_incident_fk
+FOREIGN KEY(incidentid) references incidents(id) ON DELETE CASCADE;

--- a/doc/database/airtschema.sql.in
+++ b/doc/database/airtschema.sql.in
@@ -205,7 +205,7 @@ CREATE TABLE incident_addresses (
     updated      timestamp,
     updatedby    integer,
     primary key  (id),
-    foreign key  (incident) references incidents(id),
+    foreign key  (incident) references incidents(id) on delete cascade,
     foreign key  (constituency) references constituencies(id),
     foreign key  (addedby) references users(id),
     foreign key  (updatedby) references users(id),
@@ -220,7 +220,7 @@ CREATE TABLE incident_users (
     addedby     integer not null,
     mailtemplate_override char(80),
     primary key (id),
-    foreign key (incidentid) references incidents(id),
+    foreign key (incidentid) references incidents(id) on delete cascade,
     foreign key (userid) references users(id),
     foreign key (addedby) references users(id),
     foreign key (mailtemplate_override) references mailtemplates(name)
@@ -268,7 +268,7 @@ CREATE TABLE incident_comments (
     added       timestamp not null,
     addedby     integer not null,
     primary key (id),
-    foreign key (incident) references incidents(id),
+    foreign key (incident) references incidents(id) on delete cascade,
     foreign key (addedby) references users(id)
 );
 
@@ -320,7 +320,7 @@ CREATE TABLE blocks (
     incident      integer not null,
     primary key (id),
     foreign key (lastupdatedby) references users(id),
-    foreign key (incident) references incidents(id)
+    foreign key (incident) references incidents(id) on delete cascade
 );
 
 CREATE TABLE import_queue (
@@ -374,7 +374,7 @@ CREATE TABLE external_incidentids (
   incidentid integer,
   externalid varchar(64),
   primary key (incidentid,externalid),
-  foreign key (incidentid) references incidents(id)
+  foreign key (incidentid) references incidents(id) on delete cascade
 );
 
 CREATE TABLE importqueue_templates (
@@ -394,7 +394,7 @@ CREATE TABLE incident_attachments (
    incident integer,
    filename text,
    primary key (id),
-   foreign key (incident) references incidents(id)
+   foreign key (incident) references incidents(id) on delete cascade
 );
 
 
@@ -434,7 +434,7 @@ CREATE TABLE incident_mail (
     messageid integer,
     incidentid integer,
     PRIMARY KEY (id),
-    FOREIGN KEY (messageid) REFERENCES mailbox(id),
+    FOREIGN KEY (messageid) REFERENCES mailbox(id) on delete cascade,
     FOREIGN KEY (incidentid) REFERENCES incidents(id)
 );
 

--- a/doc/database/delete_old_incidents.sql
+++ b/doc/database/delete_old_incidents.sql
@@ -1,0 +1,38 @@
+/**
+	Run this script in a cronjob/scheduled task or by hand to clean up
+	old incidents from the database.
+	
+	It will	delete any incidents, and related data, which are not "open"
+	and have last been updated over 2 years ago, from the tables
+	`incidents`, `incidents_`*, `blocks` and `mailbox`.
+
+	Additionally it will clean from the `import_queue` any item that
+	has is "open" and is older than six months.
+
+	It does not clean any other tables, such as users, constituents
+	or networks.
+
+	You need to have database migration 20180720.1.schema.sql applied.
+ */
+
+SELECT 'import_queue' AS table, status, count(*) FROM import_queue GROUP BY status;
+DELETE FROM import_queue
+	WHERE status != 'open' AND updated < NOW() - INTERVAL '6 months';
+SELECT 'import_queue' AS table, status, count(*) FROM import_queue GROUP BY status;
+
+SELECT 'incidents' AS table, count(*) as total, min(id) as oldest, max(id) as newest FROM incidents;
+DELETE FROM incidents
+	WHERE status != 1 AND updated < NOW() - INTERVAL '2 years';
+SELECT 'incidents' AS table, count(*) as total, min(id) as oldest, max(id) as newest FROM incidents;
+
+SELECT 'mailbox' AS table, count(*) as total, to_timestamp(min(date)) as oldest, to_timestamp(max(date)) as newest FROM mailbox;
+
+DELETE FROM mailbox
+  USING public.mailbox as mail
+    LEFT OUTER JOIN public.incident_mail AS incident_mail ON mail.id = incident_mail.messageid
+    WHERE public.mailbox.id = mail.id
+      AND CAST(mail.date AS BIGINT) < (CAST(EXTRACT(epoch FROM NOW()) AS BIGINT) - 63113852)
+      AND incident_mail.id IS NULL;
+
+
+SELECT 'mailbox' AS table, count(*) as total, to_timestamp(min(date)) as oldest, to_timestamp(max(date)) as newest FROM mailbox;


### PR DESCRIPTION
This PR adds the necessary on delete cascade constraints so removing incidents will properly clean up any dependent tables. Also it adds an example SQL script that will actually delete incidents older than a given period (to help e.g. with GDPR compliancy).

This PR is based on the previous IPv6 pr; it might need rebasing after that is or is not merged.